### PR TITLE
Update README for JSON extension allowed by default

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,8 +13,9 @@ composer require spicyweb/craft-embedded-assets
 
 ## Allow JSON filetype
 
-JSON files are disabled by default when uploading files to the asset manager. To fix this,
-open your `config/general.php` file add the following setting:
+Prior to Craft 3.0.23, JSON files were disabled by default when uploading files to the asset manager. 
+
+To fix this, either upgrade Craft to 3.0.23 or later, or open your `config/general.php` file and add the following setting:
 ```php
 'extraAllowedFileExtensions' => 'json'
 ```


### PR DESCRIPTION
The JSON extensions was allowed by default from 3.0.23

https://github.com/craftcms/cms/commit/db41c2fbeef923353244fd88fe23663171f2cbe3