### PR TITLE
Add `showThumbnailsInCp` setting

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -228,6 +228,13 @@ class Plugin extends BasePlugin
     private function _getThumbnailUrl(EmbeddedAsset $embeddedAsset, int $size, int $maxSize = 200)
 	{
 		$assetManagerService = Craft::$app->getAssetManager();
+		$defaultThumb = $assetManagerService->getPublishedUrl('@spicyweb/embeddedassets/resources/default-thumb.svg', true);
+
+		// If embedded asset thumbnails are disabled, just show Embedded Assets' default.
+		if (!$this->getSettings()->showThumbnailsInCp)
+		{
+			return $defaultThumb;
+		}
 
 		$url = false;
 		$image = $embeddedAsset->getImageToSize($size);
@@ -252,7 +259,7 @@ class Plugin extends BasePlugin
 			}
 			else
 			{
-				$url = $assetManagerService->getPublishedUrl('@spicyweb/embeddedassets/resources/default-thumb.svg', true);
+				$url = $defaultThumb;
 			}
 		}
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -170,6 +170,11 @@ class Settings extends Model
 	public $cacheDuration = 5 * 60; // 5 minutes
 
 	/**
+	 * @var bool
+	 */
+	public $showThumbnailsInCp = true;
+
+	/**
 	 * @return array
 	 */
 	public function rules()
@@ -180,6 +185,7 @@ class Settings extends Model
 			[['whitelist', 'extraWhitelist'], 'each', 'rule' => [StringValidator::class]],
 			[['maxAssetNameLength', 'maxFileNameLength'], 'integer', 'min' => 10],
 			['cacheDuration', 'integer', 'min' => 0],
+			['showThumbnailsInCp', 'boolean'],
 		];
 	}
 }


### PR DESCRIPTION
Controls whether embedded asset thumbnails are shown in the control panel.  Defaults to true.  When set to false, just shows Embedded Assets' default thumbnail.

Workaround for #102.