### PR TITLE
Actually catch the error thrown if the json file doesn't exist

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -140,7 +140,7 @@ class Service extends Component
 					$embeddedAsset = $this->createEmbeddedAsset($decodedJson);
 				}
 			}
-			catch (Exception $e)
+			catch (\Throwable $e)
 			{
 				// Ignore errors and assume it's not an embedded asset
 				$embeddedAsset = null;


### PR DESCRIPTION
If the JSON file is missing, but the asset exists in Craft's db, it'll throw an error. Commonly, if you've grabbed that database from production, and haven't cloned the assets locally. Its quite jarring to have this error thrown, as it stops everything in its tracks.

`PHP Warning – yii\base\ErrorException
fopen(/Users/joshcrawford/public_html/site-com-au/public_html/uploads/video.json): failed to open stream: No such file or directory`

This fix just ensures that its caught properly. You could also change this to `\Exception` if you like, but without the backslash, it won't catch the error. Throwable tends to catch warnings a little better. I suppose additional logging should also be added here in the catch statement. There's also a note about switching to `$asset->getContents()`, but not going to touch any of that (despite it works just fine)!