### PR TITLE
add fix for PHP 7.4 deprecation error

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -179,7 +179,7 @@ class Service extends Component
 				case 'code':
 				{
 					$code = $value instanceof Twig_Markup ? (string)$value :
-						is_string($value) ? $value : '';
+						(is_string($value) ? $value : '');
 
 					$embeddedAsset->$key = empty($code) ? null : Template::raw($code);
 				}


### PR DESCRIPTION
This PR fixes the deprecation error thrown by createEmbeddedAsset() in PHP 7.4. 

![image](https://user-images.githubusercontent.com/1872727/74308546-9bb8ee80-4dbc-11ea-9c7b-2fe3a0a76837.png)
