### PR TITLE
Add `referer` setting

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -15,6 +15,7 @@ use DateTimeInterface;
 use DOMDocument;
 use Embed\Embed;
 use Embed\Adapters\Adapter;
+use Embed\Http\CurlDispatcher;
 use Embed\Http\Url;
 use spicyweb\embeddedassets\Plugin as EmbeddedAssets;
 use spicyweb\embeddedassets\models\EmbeddedAsset;
@@ -93,7 +94,13 @@ class Service extends Component
             $options['facebook'] = ['key' => Craft::parseEnv($pluginSettings->facebookKey)];
         }
 
+        if ($pluginSettings->referer) {
+            $adapter = Embed::create($url, $options, new CurlDispatcher([
+                CURLOPT_REFERER => Craft::parseEnv($pluginSettings->referer),
+            ]));
+        } else {
         $adapter = Embed::create($url, $options);
+        }
 
         // Check for PBS videos
         if (($pbsCode = $this->_getPbsEmbedCode($adapter)) !== null) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -42,6 +42,11 @@ class Settings extends Model
      * @var string
      */
     public $facebookKey = '';
+
+    /**
+     * @var string
+     */
+    public $referer = '';
     
     /**
      * @var array of parameters
@@ -189,7 +194,7 @@ class Settings extends Model
         return [
             'parser' => [
                 'class' => EnvAttributeParserBehavior::class,
-                'attributes' => ['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey'],
+                'attributes' => ['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer'],
             ],
         ];
     }
@@ -200,7 +205,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey'], StringValidator::class],
+            [['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer'], StringValidator::class],
             ['parameters', 'each', 'rule' => [ParameterValidator::class]],
             [['whitelist', 'extraWhitelist'], 'each', 'rule' => [StringValidator::class]],
             [['maxAssetNameLength', 'maxFileNameLength'], 'integer', 'min' => 10],

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -62,6 +62,16 @@
 		suggestEnvVars: true
 	}) }}
 
+	{{ forms.autosuggestField({
+		label: "HTTP Referer"|t('embeddedassets'),
+		instructions: "Domain to set as HTTP Referer, e.g. `https://domain.com`"|t('embeddedassets'),
+		id: 'referer',
+		name: 'referer',
+		value: settings.referer,
+		errors: settings.getErrors('referer'),
+		suggestEnvVars: true
+	}) }}
+
 	{{ forms.editableTableField({
 		label: "Parameters"|t('embeddedassets'),
 		instructions: "List of extra parameters and their values to be sent when retrieving embed data."|t('embeddedassets'),


### PR DESCRIPTION
Addresses #139. Summary of changes:

- add new `referer` setting
- if set, pass an instance of `CurlDispatcher`, with `CURLOPT_REFERER` set to the setting value, when creating the Embed adapter via `Embed::create()`.

I have not tested this with all providers, but quick tests with Youtube, Instagram and Facebook both appear unaffected. And of course, it now works with Vimeo when the video is restricted to the domain.