### PR TITLE
Add setting to pass `custom_adapters_namespace` to Embed config

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -93,13 +93,16 @@ class Service extends Component
         if ($pluginSettings->facebookKey) {
             $options['facebook'] = ['key' => Craft::parseEnv($pluginSettings->facebookKey)];
         }
+        if ($pluginSettings->customAdaptersNamespace) {
+            $options['custom_adapters_namespace'] = Craft::parseEnv($pluginSettings->customAdaptersNamespace);
+        }
 
         if ($pluginSettings->referer) {
             $adapter = Embed::create($url, $options, new CurlDispatcher([
                 CURLOPT_REFERER => Craft::parseEnv($pluginSettings->referer),
             ]));
         } else {
-        $adapter = Embed::create($url, $options);
+            $adapter = Embed::create($url, $options);
         }
 
         // Check for PBS videos

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -49,6 +49,11 @@ class Settings extends Model
     public $referer = '';
     
     /**
+     * @var string
+     */
+    public $customAdaptersNamespace = '';
+
+    /**
      * @var array of parameters
      */
     public $parameters = [
@@ -194,7 +199,7 @@ class Settings extends Model
         return [
             'parser' => [
                 'class' => EnvAttributeParserBehavior::class,
-                'attributes' => ['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer'],
+                'attributes' => ['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer', 'customAdaptersNamespace'],
             ],
         ];
     }
@@ -205,7 +210,7 @@ class Settings extends Model
     public function rules()
     {
         return [
-            [['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer'], StringValidator::class],
+            [['embedlyKey', 'iframelyKey', 'googleKey', 'soundcloudKey', 'facebookKey', 'referer', 'customAdaptersNamespace'], StringValidator::class],
             ['parameters', 'each', 'rule' => [ParameterValidator::class]],
             [['whitelist', 'extraWhitelist'], 'each', 'rule' => [StringValidator::class]],
             [['maxAssetNameLength', 'maxFileNameLength'], 'integer', 'min' => 10],

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -72,6 +72,16 @@
 		suggestEnvVars: true
 	}) }}
 
+    {{ forms.autosuggestField({
+        label: "Custom Adapters Namespace"|t('embeddedassets'),
+        instructions: "Namespace used to load custom adapters, e.g. `modules\\mymodule\\adapters\\`"|t('embeddedassets'),
+        id: 'customAdaptersNamespace',
+        name: 'customAdaptersNamespace',
+        value: settings.customAdaptersNamespace,
+        errors: settings.getErrors('customAdaptersNamespace'),
+        suggestEnvVars: true
+    }) }}
+
 	{{ forms.editableTableField({
 		label: "Parameters"|t('embeddedassets'),
 		instructions: "List of extra parameters and their values to be sent when retrieving embed data."|t('embeddedassets'),


### PR DESCRIPTION
Embed v3 supports a [`custom_adapters_namespace` option](https://github.com/oscarotero/Embed/tree/v3.x#the-adapter) that allows applications to override or extend its adapter classes in order to modify behavior or support additional providers. 

This adds a new `customAdaptersNamespace` setting to the plugin and passes its value along to the Embed adapter instance. 