### PR TITLE
GraphQL : allow custom iFrame embeds via videoUrl with params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "spicyweb/craft-embedded-assets",
   "description": "Manage YouTube videos, Instagram photos, Twitter posts and more as first class assets",
-  "version": "2.5.3",
+  "version": "2.5.4-dev",
   "type": "craft-plugin",
   "keywords": [
     "cms",

--- a/src/gql/interfaces/EmbeddedAsset.php
+++ b/src/gql/interfaces/EmbeddedAsset.php
@@ -109,7 +109,19 @@ class EmbeddedAsset extends Element
             'url' => [
                 'name' => 'url',
                 'type' => Type::string(),
-                'description' => 'The url of the embedded asset.'
+                'description' => 'The url of the embedded asset.',
+                'args' => [
+                    'asVideoUrl' => [
+                        'name' => 'asVideoUrl',
+                        'description' => 'Should the URL be returned as a Video URL?',
+                        'type' => Type::boolean()
+                    ],
+                    'params' => [
+                        'name' => 'params',
+                        'description' => "A list of params which will be added to the URL. For example: ['autoplay=1', 'controls=0', 'playsinline=1']",
+                        'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
+                    ],
+                ],
             ],
             'type' => [
                 'name' => 'type',

--- a/src/gql/interfaces/EmbeddedAsset.php
+++ b/src/gql/interfaces/EmbeddedAsset.php
@@ -119,7 +119,7 @@ class EmbeddedAsset extends Element
                     'params' => [
                         'name' => 'params',
                         'description' => "A list of params which will be added to the URL. For example: ['autoplay=1', 'controls=0', 'playsinline=1']",
-                        'type' => Type::nonNull(Type::listOf(Type::nonNull(Type::string()))),
+                        'type' => Type::listOf(Type::nonNull(Type::string())),
                     ],
                 ],
             ],

--- a/src/gql/interfaces/EmbeddedAsset.php
+++ b/src/gql/interfaces/EmbeddedAsset.php
@@ -124,7 +124,7 @@ class EmbeddedAsset extends Element
                     'params' => [
                         'name' => 'params',
                         'description' => "A list of params which will be added to the URL. For example: ['autoplay=1', 'controls=0', 'playsinline=1']",
-                        'type' => Type::listOf(ype::string()),
+                        'type' => Type::listOf(Type::string()),
                     ],
                 ],
             ],

--- a/src/gql/interfaces/EmbeddedAsset.php
+++ b/src/gql/interfaces/EmbeddedAsset.php
@@ -116,10 +116,15 @@ class EmbeddedAsset extends Element
                         'description' => 'Should the URL be returned as a Video URL?',
                         'type' => Type::boolean()
                     ],
+                    'asVideoCode' => [
+                        'name' => 'asVideoCode',
+                        'description' => 'Should the URL be returned as a Video Code?',
+                        'type' => Type::boolean()
+                    ],
                     'params' => [
                         'name' => 'params',
                         'description' => "A list of params which will be added to the URL. For example: ['autoplay=1', 'controls=0', 'playsinline=1']",
-                        'type' => Type::listOf(Type::nonNull(Type::string())),
+                        'type' => Type::listOf(ype::string()),
                     ],
                 ],
             ],

--- a/src/gql/interfaces/EmbeddedAsset.php
+++ b/src/gql/interfaces/EmbeddedAsset.php
@@ -116,11 +116,6 @@ class EmbeddedAsset extends Element
                         'description' => 'Should the URL be returned as a Video URL?',
                         'type' => Type::boolean()
                     ],
-                    'asVideoCode' => [
-                        'name' => 'asVideoCode',
-                        'description' => 'Should the URL be returned as a Video Code?',
-                        'type' => Type::boolean()
-                    ],
                     'params' => [
                         'name' => 'params',
                         'description' => "A list of params which will be added to the URL. For example: ['autoplay=1', 'controls=0', 'playsinline=1']",

--- a/src/gql/types/EmbeddedAsset.php
+++ b/src/gql/types/EmbeddedAsset.php
@@ -34,15 +34,15 @@ class EmbeddedAsset extends Element
         /* @var EmbeddedAsset $source */
         $fieldName = $resolveInfo->fieldName;
 
-        if ($fieldName === 'url') {
-            if($arguments['asVideoUrl']) {
+        if(!empty($arguments) && $fieldName === 'url') {
+            if($arguments['asVideoUrl'] === TRUE) {
                 return $source->getVideoUrl($arguments['params'] ?? []);
             }
-            if($arguments['asVideoCode']) {
+            if($arguments['asVideoCode'] === TRUE) {
                 return $source->getVideoCode($arguments['params'] ?? []);
             }
         }
-
         return parent::resolve($source, $arguments, $context, $resolveInfo);
+
     }
 }

--- a/src/gql/types/EmbeddedAsset.php
+++ b/src/gql/types/EmbeddedAsset.php
@@ -38,9 +38,6 @@ class EmbeddedAsset extends Element
             if($arguments['asVideoUrl'] === TRUE) {
                 return $source->getVideoUrl($arguments['params'] ?? []);
             }
-            if($arguments['asVideoCode'] === TRUE) {
-                return $source->getVideoCode($arguments['params'] ?? []);
-            }
         }
         return parent::resolve($source, $arguments, $context, $resolveInfo);
 

--- a/src/gql/types/EmbeddedAsset.php
+++ b/src/gql/types/EmbeddedAsset.php
@@ -2,7 +2,10 @@
 
 namespace spicyweb\embeddedassets\gql\types;
 
+use Craft;
 use craft\gql\types\elements\Element;
+use craft\helpers\Gql;
+use GraphQL\Type\Definition\ResolveInfo;
 use spicyweb\embeddedassets\gql\interfaces\EmbeddedAsset as EmbeddedAssetInterface;
 
 /**
@@ -21,5 +24,22 @@ class EmbeddedAsset extends Element
         $config['interfaces'] = [EmbeddedAssetInterface::getType()];
 
         parent::__construct($config);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function resolve($source, $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        /* @var EmbeddedAsset $source */
+        $fieldName = $resolveInfo->fieldName;
+
+        if ($fieldName === 'url') {
+            if($arguments['asVideoUrl']) {
+                return $source->getVideoUrl($arguments['params'] ?? []);
+            }
+        }
+
+        return parent::resolve($source, $arguments, $context, $resolveInfo);
     }
 }

--- a/src/gql/types/EmbeddedAsset.php
+++ b/src/gql/types/EmbeddedAsset.php
@@ -38,6 +38,9 @@ class EmbeddedAsset extends Element
             if($arguments['asVideoUrl']) {
                 return $source->getVideoUrl($arguments['params'] ?? []);
             }
+            if($arguments['asVideoCode']) {
+                return $source->getVideoCode($arguments['params'] ?? []);
+            }
         }
 
         return parent::resolve($source, $arguments, $context, $resolveInfo);


### PR DESCRIPTION
This small extension allows the user to return the URL as the `videoUrl` based on the `$this->getVideoUrl($params)` function. It also accepts params to create for example autoplaying background videos with Vimeo videos.

# Usage

```gql
fragment Asset on AssetInterface {
  title
  embeddedAsset {
    html
    image
    type
    imageWidth
    imageHeight
    image
    url(asVideoUrl: true, params: ["autoplay=1", "background=1"])
    providerName
    aspectRatio
  }
}