### PR TITLE
feat: make `CurlDispatcher` configuration modifiable through Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Changed
+- Updated `spicyweb\embeddedassets\events\BeforeCreateAdapterEvent` to allow custom configuration of `Dispatcher` instance
+
 ## 2.8.0 - 2021-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Embedded assets are just JSON files. This means they can exist as real assets wi
 - [Templating](docs/templating.md)
 - [GraphQL](docs/graphql.md)
 - [Configuration](docs/configuration.md)
+- [Events](docs/events.md)
 - [Changelog](CHANGELOG.md)
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,6 @@
 # Configuration
 
 Some of Embedded Assets settings can be configured through the control panel. Navigate to **Settings &rarr; Embedded Assets** to find these settings.
+
+## HTTP Referer
+Set a `Referer` HTTP header on the request. By default no `Referer` header is send by curl. In some cases it is necessary to add this header. An example would be a Vimeo video with [domain-level privacy](https://developer.vimeo.com/api/oembed/videos#embedding-videos-with-domain-privacy).

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,27 @@
+# Events
+
+Embedded Assets uses events to allow other plugins or modules to interact with Embedded Assets' functionality.
+
+## BeforeCreateAdapterEvent
+This event is fired before the instantiation of the `Adapter`. It allows modifying the `url` and the `config` parameters. 
+
+This event also has a `dispatcherConfig` property that can be modified. This config is used for the instantiation of the `Dispatcher` used by the `Adapter`. As Embedded Assets always uses a `CurlDispatcher` instance, the relevant options can be found at [https://github.com/oscarotero/Embed/tree/3.4.17#the-dispatcher](https://github.com/oscarotero/Embed/tree/3.4.17#the-dispatcher).
+
+### Example
+
+A Vimeo video with domain-level privacy needs to have the `Referer` HTTP header configured, but also needs to be requested with a common browser `User-Agent` HTTP header, otherwise a bare-bones oEmbed JSON object will be returned. This would be setup by adding the correct option to the `dispatchConfig`: 
+
+```php
+use spicyweb\embeddedassets\events\BeforeCreateAdapterEvent;
+use spicyweb\embeddedassets\Service;
+use yii\base\Event;
+
+Event::on(
+    Service::class,
+    Service::EVENT_BEFORE_CREATE_ADAPTER,
+    static function (BeforeCreateAdapterEvent $event) {
+        $event->dispatcherConfig[CURLOPT_USERAGENT] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36';
+    }
+);
+```
+

--- a/src/events/BeforeCreateAdapterEvent.php
+++ b/src/events/BeforeCreateAdapterEvent.php
@@ -22,4 +22,10 @@ Class BeforeCreateAdapterEvent extends Event
      * @see https://github.com/oscarotero/Embed/tree/3.4.17#the-adapter
      */
     public $options = [];
+
+    /**
+     * @var array
+     * @see https://github.com/oscarotero/Embed/tree/3.4.17#the-dispatcher
+     */
+    public $dispatcherConfig = [];
 }


### PR DESCRIPTION
Allowing changes to configuration used in instantiating `CurlDispatcher` also allows to add a `User-Agent` header, which, together with setting a correct `Referer` through settings, fixes the following use case: https://github.com/oscarotero/Embed/issues/377

Summarized: a Vimeo video that is restricted to embedding on certain domain only - domain-level privacy - outputs very basic oembed json, without image info. Passing in the domain as a `Referer` is not enough to get the expected oembed json, also a common browser user-agent needs to be passed in `User-Agent` header.

I was honestly doubting a bit between allowing modification of the config versus allowing providing a custom instance, and using the existing event vs using a new event.

As using the existing event and modifying a config is the smallest incremental change, I landed on this.