### PR TITLE
Fix deprecation warnings during asset refresh

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -371,10 +371,12 @@ class Service extends Component
         $folder = $asset->getFolder();
         $newEmbeddedAsset = $this->requestUrl($embeddedAsset->url, false);
 
-        // Retain deprecated property values not supported by Embed 4
-        foreach (['imageHeight', 'imageWidth', 'images', 'providerIcons', 'tags', 'type'] as $prop) {
-            $newEmbeddedAsset->{$prop} = $embeddedAsset->{$prop};
+        // Retain deprecated property values not supported by Embed 4 without triggering deprecation warnings
+        foreach ($embeddedAsset->getDeprecatedPropertyValues() as $prop => $value) {
+            $newEmbeddedAsset->{$prop} = $value;
         }
+
+        $newEmbeddedAsset->type = $embeddedAsset->type;
 
         $newAsset = $this->createAsset($newEmbeddedAsset, $folder);
         $result = $elementsService->saveElement($newAsset);

--- a/src/models/EmbeddedAsset.php
+++ b/src/models/EmbeddedAsset.php
@@ -200,6 +200,25 @@ class EmbeddedAsset extends Model implements JsonSerializable
     }
 
     /**
+     * Returns deprecated property values without triggering their deprecation accessors.
+     *
+     * This is used internally when refreshing an existing embedded asset so the values can be
+     * retained for backwards compatibility without logging deprecation warnings.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDeprecatedPropertyValues(): array
+    {
+        $values = [];
+
+        foreach (static::deprecatedProperties() as $property) {
+            $values[$property] = $this->{"_$property"};
+        }
+
+        return $values;
+    }
+
+    /**
      * @inheritdoc
      */
     public function __construct($config = [])


### PR DESCRIPTION
## Summary

- Preserve deprecated embedded asset values through an internal accessor.
- Avoid triggering deprecation warnings when refreshing existing assets.
- Keep the existing `type` preservation behavior unchanged.

The current implementation reads `imageHeight`, `imageWidth`, `images`, `providerIcons`, and `tags` through `EmbeddedAsset::__get()` in `Service::refreshEmbeddedAsset()`. That logs deprecation warnings during Instagram refresh queue jobs.

This change reads the backing values from within the model, where no deprecation accessor is invoked, while preserving the backward-compatibility data written to refreshed assets.

Validated with:

- `php -l src/Service.php`
- `php -l src/models/EmbeddedAsset.php`
- `git diff --check`

Fixes #302
Related to #291